### PR TITLE
Add scrollbar always (also on non scroll pages)

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -9,6 +9,7 @@ body {
     grid-template-areas: 
         "nav app";
     grid-template-columns: 25% 75%;
+    overflow-y: scroll;
 }
 
 nav {


### PR DESCRIPTION
It is nicer for page switch. If you switch the page the site doesn't toggle the scrollbar which is nicer for the eyes. Frameworks like bulma also have this.